### PR TITLE
fix Android java src folder destination

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -39,6 +39,6 @@
 						<param name="android-package" value="com.hutchind.cordova.plugins.Launcher" />
 				</feature>
 			</config-file>
-			<source-file src="src/android/Launcher.java" target-dir="src/com/hutchind/cordova/plugins/launcher" />
+			<source-file src="src/android/Launcher.java" target-dir="src/com/hutchind/cordova/plugins" />
 	</platform>
 </plugin>


### PR DESCRIPTION
The Java file destination is not correct and make ADT (Eclipse) fail to find this package without this fix.
