### PR TITLE
Fix: iOS 18 openURL(_:) is deprecated, New: launchApp and launchAppWithData now they can use the flag FLAG_ACTIVITY_NEW_TASK

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ Simple Cordova plugin to see if other apps are installed and launch them.
 ## 0. Index
 1. [Description](#1-description)
 2. [Installation](#2-installation)
-3. [Usage](#3-usage)
-4. [Changelog](#4-changelog)
-5. [Credits](#5-credits)
-6. [License](#6-license)
+3. [Parameters](#3-parameters)
+4. [Usage](#4-usage)
+5. [Changelog](#5-changelog)
+6. [Credits](#6-credits)
+7. [License](#7-license)
 
 ## 1. Description
 
@@ -85,7 +86,84 @@ For iOS 9+, the following may need to be added so that the URLs used to launch a
 </gap:config-file>
 ```
 
-## 3. Usage
+## 3. Parameters
+
+List of parameters that can be passed to `window.plugins.launcher.launch` and `window.plugins.launcher.canLaunch`
+
+**uri**, can be used in `launch` and `canLaunch` (**iOS** and **Android**)
+
+```javascript
+	window.plugins.launcher.launch({
+		uri:'http://nasatv-lh.akamaihd.net/i/NASA_101@319270/master.m3u8',
+	}, successCallback, errorCallback);
+```
+
+**packageName**, can be used in `launch` and `canLaunch` (**Android**)
+
+```javascript
+	window.plugins.launcher.launch({
+		uri:'http://nasatv-lh.akamaihd.net/i/NASA_101@319270/master.m3u8',
+		packageName:'com.mxtech.videoplayer.ad',
+	}, successCallback, errorCallback);
+```
+
+**dataType**, can be used in `launch` and `canLaunch` (**Android**)
+
+```javascript
+	window.plugins.launcher.launch({
+		uri:'http://nasatv-lh.akamaihd.net/i/NASA_101@319270/master.m3u8',
+		packageName:'com.mxtech.videoplayer.ad',
+		dataType:'application/x-mpegURL'
+	}, successCallback, errorCallback);
+```
+
+**flags**, can be used in `launch` (**Android**)
+
+```javascript
+	window.plugins.launcher.launch({
+		uri:'http://nasatv-lh.akamaihd.net/i/NASA_101@319270/master.m3u8',
+		packageName:'com.mxtech.videoplayer.ad',
+		dataType:'application/x-mpegURL',
+		flags: window.plugins.launcher.FLAG_ACTIVITY_NEW_TASK,
+	}, successCallback, errorCallback);
+```
+
+Abailable flags
+
+- **FLAG_ACTIVITY_NEW_TASK**: If set, this activity will become the start of a new task (Open the app in a new activity instead of the current one).
+
+If you are missing some flags, you can use its int value or edit and add it in the file [Launcher.js](https://github.com/nchutchind/cordova-plugin-app-launcher/blob/master/www/Launcher.js) and open a pull request, see all [Intent flags list](https://developer.android.com/reference/android/content/Intent).
+
+**extras**, can be used in `launch` (**Android**)
+
+More info in [Extras Data Types](#extras-data-types) and below.
+
+```javascript
+	window.plugins.launcher.launch({
+		uri:'http://nasatv-lh.akamaihd.net/i/NASA_101@319270/master.m3u8',
+		packageName:'com.mxtech.videoplayer.ad',
+		dataType:'application/x-mpegURL',
+		flags: window.plugins.launcher.FLAG_ACTIVITY_NEW_TASK,
+		extras: [
+			{"name":"position", "value":3000, "dataType":"int"}
+		]
+	}, successCallback, errorCallback);
+```
+
+**getAppList**, can be used in `canLaunch` (**Android**)
+
+`successCallback` data will contain an array named `appList` with the package names of applications that can handle the uri specified.
+
+```javascript
+	window.plugins.launcher.canLaunch({
+		uri:'http://nasatv-lh.akamaihd.net/i/NASA_101@319270/master.m3u8',
+		packageName:'com.mxtech.videoplayer.ad',
+		dataType:'application/x-mpegURL',
+		getAppList: true,
+	}, successCallback, errorCallback);
+```
+
+## 4. Usage
 ```javascript
 	// Default handlers
 	var successCallback = function(data) {
@@ -214,7 +292,7 @@ Check to see if Peek Acuity can be launched via an Action Name (**Android**)
 ```typescript
 	let actionName = 'org.peekvision.intent.action.TEST_ACUITY';
 
-	window["plugins"].launcher.canLaunch({actionName: actionName},
+	window.plugins.launcher.canLaunch({actionName: actionName},
 		data => console.log("Peek Acuity can be launched"),
 		errMsg => console.log("Peek Acuity not installed! " + errMsg)
 	);
@@ -234,7 +312,7 @@ Launch Peek Acuity via an Action Name with Extras and return results (**Android*
 	  {"name":"return_result",	"value":true,		"dataType":"Boolean"}
 	];
 
-	window["plugins"].launcher.launch({actionName: actionName, extras: extras},
+	window.plugins.launcher.launch({actionName: actionName, extras: extras},
 		json => {
 			if (json.isActivityDone) {
 				if (json.data) {
@@ -329,7 +407,7 @@ Activity launched and data returned
 #### Launcher.launch Error Callback Data
 Passes an error message as a string.
 
-## 4. Changelog
+## 5. Changelog
 0.4.0: Android: Added ability to launch with intent. Thanks to [@mmey3k] for the code.
 
 0.2.0: Android: Added ability to launch activity with extras and receive data back from launched app when it is finished.
@@ -340,10 +418,10 @@ Passes an error message as a string.
 
 0.1.0: initial version supporting Android and iOS
 
-## 5. Credits
+## 6. Credits
 Special thanks to [@michael1t](https://github.com/michael1t) for sponsoring the development of the Extras portion of this plugin.
 
-## 6. License
+## 7. License
 
 [The MIT License (MIT)](http://www.opensource.org/licenses/mit-license.html)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-app-launcher",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "This plugin allows you to see if other apps are installed and launch them. On Android, you can send extras to the launched Activity and receive result data (if available), as well as retrieve a list of applications that can open a specified uri.",
   "repository": {
     "type": "git",

--- a/src/android/Launcher.java
+++ b/src/android/Launcher.java
@@ -34,7 +34,7 @@ import java.util.Set;
 import java.util.HashSet;
 
 public class Launcher extends CordovaPlugin {
-	public static final String TAG = "Launcher Plugin";
+	public static final String TAG = "LauncherPlugin";
 	public static final String ACTION_CAN_LAUNCH = "canLaunch";
 	public static final String ACTION_LAUNCH = "launch";
 	public static final int LAUNCH_REQUEST = 0;
@@ -202,16 +202,16 @@ public class Launcher extends CordovaPlugin {
 			if (options.has("dataType")) {
 				dataType = options.getString("dataType");
 			}
-			launchAppWithData(packageName, options.getString("uri"), dataType, extras);
+			launchAppWithData(packageName, options.getString("uri"), dataType, extras, flags);
 			return true;
 		} else if (options.has("packageName")) {
-			launchApp(options.getString("packageName"), extras);
+			launchApp(options.getString("packageName"), extras, flags);
 			return true;
 		} else if (options.has("uri")) {
 			launchIntent(options.getString("uri"), extras, flags);
 			return true;
 		} else if (options.has("actionName")) {
-			launchAction(options.getString("actionName"), extras);
+			launchAction(options.getString("actionName"), extras, flags);
 			return true;
 		}
 		return false;
@@ -343,7 +343,7 @@ public class Launcher extends CordovaPlugin {
 		return extras;
 	}
 
-	private void launchAppWithData(final String packageName, final String uri, final String dataType, final Bundle extras) throws JSONException {
+	private void launchAppWithData(final String packageName, final String uri, final String dataType, final Bundle extras, final int flags) throws JSONException {
 		final CordovaInterface mycordova = cordova;
 		final CordovaPlugin plugin = this;
 		final CallbackContext callbackContext = this.callback;
@@ -360,7 +360,9 @@ public class Launcher extends CordovaPlugin {
 					intent.setPackage(packageName);
 				}
 
-				intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+				if (flags != 0) {
+					intent.addFlags(flags);
+				}
 
 				intent.putExtras(extras);
 
@@ -377,7 +379,7 @@ public class Launcher extends CordovaPlugin {
 		});
 	}
 
-	private void launchApp(final String packageName, final Bundle extras) {
+	private void launchApp(final String packageName, final Bundle extras, final int flags) {
 		final CordovaInterface mycordova = cordova;
 		final CordovaPlugin plugin = this;
 		Log.i(TAG, "Trying to launch app: " + packageName);
@@ -388,7 +390,9 @@ public class Launcher extends CordovaPlugin {
 				boolean appNotFound = launchIntent == null;
 
 				if (!appNotFound) {
-					launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+					if (flags != 0) {
+						launchIntent.addFlags(flags);
+					}
 					try {
 						launchIntent.putExtras(extras);
 						mycordova.startActivityForResult(plugin, launchIntent, LAUNCH_REQUEST);
@@ -413,9 +417,8 @@ public class Launcher extends CordovaPlugin {
 				Intent intent = new Intent(Intent.ACTION_VIEW);
 				intent.setData(Uri.parse(uri));
 				if (flags != 0) {
-					intent.setFlags(flags);
+					intent.addFlags(flags);
 				}
-				// intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK); // It can be passed on the flags
 				try {
 					intent.putExtras(extras);
 					mycordova.startActivityForResult(plugin, intent, LAUNCH_REQUEST);
@@ -429,13 +432,15 @@ public class Launcher extends CordovaPlugin {
 		});
 	}
 
-	private void launchAction(final String actionName, final Bundle extras) {
+	private void launchAction(final String actionName, final Bundle extras, final int flags) {
 		final CordovaInterface mycordova = cordova;
 		final CordovaPlugin plugin = this;
 		cordova.getThreadPool().execute(new LauncherRunnable(this.callback) {
 			public void run() {
 				Intent intent = new Intent(actionName);
-				// intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+				if (flags != 0) {
+					intent.addFlags(flags);
+				}
 				try {
 					intent.putExtras(extras);
 					mycordova.startActivityForResult(plugin, intent, LAUNCH_REQUEST);

--- a/src/android/Launcher.java
+++ b/src/android/Launcher.java
@@ -360,6 +360,8 @@ public class Launcher extends CordovaPlugin {
 					intent.setPackage(packageName);
 				}
 
+				intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
 				intent.putExtras(extras);
 
 				try {
@@ -386,6 +388,7 @@ public class Launcher extends CordovaPlugin {
 				boolean appNotFound = launchIntent == null;
 
 				if (!appNotFound) {
+					launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 					try {
 						launchIntent.putExtras(extras);
 						mycordova.startActivityForResult(plugin, launchIntent, LAUNCH_REQUEST);
@@ -412,6 +415,7 @@ public class Launcher extends CordovaPlugin {
 				if (flags != 0) {
 					intent.setFlags(flags);
 				}
+				// intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK); // It can be passed on the flags
 				try {
 					intent.putExtras(extras);
 					mycordova.startActivityForResult(plugin, intent, LAUNCH_REQUEST);
@@ -431,6 +435,7 @@ public class Launcher extends CordovaPlugin {
 		cordova.getThreadPool().execute(new LauncherRunnable(this.callback) {
 			public void run() {
 				Intent intent = new Intent(actionName);
+				// intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 				try {
 					intent.putExtras(extras);
 					mycordova.startActivityForResult(plugin, intent, LAUNCH_REQUEST);

--- a/src/ios/Launcher.m
+++ b/src/ios/Launcher.m
@@ -1,3 +1,4 @@
+
 #import "Launcher.h"
 #import <Cordova/CDV.h>
 
@@ -30,7 +31,11 @@
 		NSString *uri = [options objectForKey:@"uri"];
 		if ([[UIApplication sharedApplication] canOpenURL: [NSURL URLWithString:uri]]) {
 			NSURL *launchURL = [NSURL URLWithString:uri];
-			[[UIApplication sharedApplication] openURL: launchURL];
+			if (@available(iOS 10.0, *)) {
+				[[UIApplication sharedApplication] openURL:launchURL options:@{} completionHandler:nil];
+			} else {
+				[[UIApplication sharedApplication] openURL: launchURL];
+			}
 			pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
 			[self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 		} else {

--- a/www/Launcher.js
+++ b/www/Launcher.js
@@ -1,6 +1,7 @@
 "use strict";
 function Launcher() {}
 
+// Flags
 Launcher.prototype.FLAG_ACTIVITY_NEW_TASK = 0x10000000;
 
 Launcher.prototype.canLaunch = function (options, successCallback, errorCallback) {


### PR DESCRIPTION
It is preferable that an external app is opened in a new task than within the app itself.

@nchutchind If you feel the changes are appropriate, I'd appreciate it if they were merged.